### PR TITLE
Fix minor issues in example 02 (batch vs real-time)

### DIFF
--- a/basics/02-batch-vs-realtime/README.md
+++ b/basics/02-batch-vs-realtime/README.md
@@ -63,10 +63,10 @@ cp ../.env.example .env
 # Edit .env and add your SPEECHMATICS_API_KEY
 
 # Try batch mode
-python batch_example.py
+python3 batch_example.py
 
 # Try real-time mode
-python realtime_example.py
+python3 realtime_example.py
 ```
 
 ## Batch vs Real-time
@@ -347,7 +347,7 @@ File size: 0.7 MB
 Complete! Processing time: 0m 5s
 
 Full transcript:
-"SPEAKER UU: Good morning, everyone. Let's begin today's meeting."
+"SPEAKER UU: Good morning everyone. Let's begin today's meeting."
 ```
 
 ### Real-time Output

--- a/basics/02-batch-vs-realtime/python/requirements.txt
+++ b/basics/02-batch-vs-realtime/python/requirements.txt
@@ -4,6 +4,7 @@ speechmatics-rt>=0.5.1
 
 # Utilities
 python-dotenv>=1.0.0
+typing_extensions>=4.0.0
 
 # Audio input (for microphone support in real-time example)
 pyaudio>=0.2.11


### PR DESCRIPTION
 ## Summary

   Found during dogfooding of the Academy basics examples.

   - **Add `typing_extensions` to requirements.txt** —
   `speechmatics-rt==1.0.0` imports `typing_extensions.Self` internally but
   doesn't declare it as a dependency, causing a `ModuleNotFoundError` on a
   clean install. Adding it explicitly to requirements unblocks the real-time
    example.
   - **Fix `python` → `python3` in Quick Start Step 3** — Step 2 correctly
   uses `python3` on Mac/Linux but Step 3 dropped back to `python`, which can
    fail on systems where `python` isn't on PATH.
   - **Fix expected batch output** — the sample transcript in the README had
   a comma after "Good morning" that doesn't match the actual API response.

   ## Test plan

   - [ ] Fresh `pip install -r requirements.txt` installs `typing_extensions`
    and `python realtime_example.py` imports cleanly
   - [ ] Batch example runs and output matches the updated expected output in
    README