### PR TITLE
Fix example 07 turn detection: duration calculation and partial display

### DIFF
--- a/basics/07-turn-detection/README.md
+++ b/basics/07-turn-detection/README.md
@@ -114,7 +114,8 @@ def handle_end_of_utterance(message):
 ```
 
 > [!Important]
-> The `metadata.end_time` represents when silence was detected, not the utterance duration. To calculate duration, track the start time from your first transcript.
+> The `metadata.start_time` represents when speech was started.
+> The `metadata.end_time` represents when silence was detected, not the utterance duration. To calculate duration, track both start and end times.
 
 ### Calculating Utterance Duration
 

--- a/basics/07-turn-detection/README.md
+++ b/basics/07-turn-detection/README.md
@@ -141,6 +141,7 @@ def handle_end_of_utterance(message):
     if current_utterance and utterance_start_time is not None:
         full_text = " ".join(current_utterance)
 
+        # metadata.end_time is the silence-detection timestamp, not the end of speech.
         end_time = message.get("metadata", {}).get("end_time", 0)
         duration = end_time - utterance_start_time
 

--- a/basics/07-turn-detection/README.md
+++ b/basics/07-turn-detection/README.md
@@ -106,12 +106,15 @@ def handle_end_of_utterance(message):
     # Message structure:
     # {
     #     "message": "EndOfUtterance",
-    #     "end_of_utterance_time": 12.5  # Timestamp when silence was detected
+    #     "metadata": {
+    #         "start_time": 12.5,
+    #         "end_time": 12.5  # Timestamp when silence was detected
+    #     }
     # }
 ```
 
 > [!Important]
-> The `end_of_utterance_time` represents when silence was detected, not the utterance duration. To calculate duration, track the start time from your first transcript.
+> The `metadata.end_time` represents when silence was detected, not the utterance duration. To calculate duration, track the start time from your first transcript.
 
 ### Calculating Utterance Duration
 
@@ -138,8 +141,7 @@ def handle_end_of_utterance(message):
     if current_utterance and utterance_start_time is not None:
         full_text = " ".join(current_utterance)
 
-        # END_OF_UTTERANCE has end_of_utterance_time directly in message
-        end_time = message.get("end_of_utterance_time", 0)
+        end_time = message.get("metadata", {}).get("end_time", 0)
         duration = end_time - utterance_start_time
 
         print(f"Turn: {full_text} ({duration:.2f}s)")

--- a/basics/07-turn-detection/README.md
+++ b/basics/07-turn-detection/README.md
@@ -107,8 +107,8 @@ def handle_end_of_utterance(message):
     # {
     #     "message": "EndOfUtterance",
     #     "metadata": {
-    #         "start_time": 12.5,
-    #         "end_time": 12.5  # Timestamp when silence was detected
+    #         "start_time": 12.5, # Silence-detection timestamp (same as end_time)
+    #         "end_time": 12.5  # # Silence-detection timestamp (same as start_time)   
     #     }
     # }
 ```

--- a/basics/07-turn-detection/python/main.py
+++ b/basics/07-turn-detection/python/main.py
@@ -75,7 +75,7 @@ async def main() -> None:
                 result = TranscriptResult.from_message(message)
                 transcript = result.metadata.transcript
                 if transcript:
-                    print(f"\r> {transcript}", end="", flush=True)
+                    print(f"> {transcript}")
 
             @client.on(ServerMessageType.ADD_TRANSCRIPT)
             def handle_transcript(message):
@@ -91,13 +91,11 @@ async def main() -> None:
             @client.on(ServerMessageType.END_OF_UTTERANCE)
             def handle_end_of_utterance(message):
                 nonlocal utterance_start_time
-                print("\r" + " " * 80, end="\r")
 
                 if current_utterance and utterance_start_time is not None:
                     full_text = " ".join(current_utterance)
 
-                    # END_OF_UTTERANCE has end_of_utterance_time directly in message
-                    end_time = message.get("end_of_utterance_time", 0)
+                    end_time = message.get("metadata", {}).get("end_time", 0)
                     duration = end_time - utterance_start_time
 
                     utterances.append({"text": full_text, "duration": duration})

--- a/basics/07-turn-detection/python/main.py
+++ b/basics/07-turn-detection/python/main.py
@@ -95,6 +95,7 @@ async def main() -> None:
                 if current_utterance and utterance_start_time is not None:
                     full_text = " ".join(current_utterance)
 
+                    # metadata.end_time is the silence-detection timestamp, not the end of speech.
                     end_time = message.get("metadata", {}).get("end_time", 0)
                     duration = end_time - utterance_start_time
 


### PR DESCRIPTION
  Two fixes to the turn detection example across 2 files (8 insertions, 8 deletions):

  python/main.py

  - Fix EndOfUtterance duration: message.get("end_of_utterance_time", 0) doesn't exist in the
   server message and always defaulted to 0, producing negative durations like -4.52s.
  Correct field is metadata.end_time.
  - Replace \r + 80-space line-clear trick with plain print() per partial. Simpler and more
  readable for a learning example.

  README.md

  - Update message structure diagram and code snippets to reflect metadata.end_time instead
  of the incorrect end_of_utterance_time.

  Note: Partial transcripts show a sliding window of recent words rather than the full
  growing sentence — this is SDK behaviour, not something the example controls. Left as-is
  for now.
