### PR TITLE
Fix voice agent 'external' preset manual turn detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ basics/11-voice-api-explorer/assets/sample_mono.wav
 basics/11-voice-api-explorer/python/sample.wav
 
 basics/11-voice-api-explorer/python/test_mulaw.py
+
+basics/08-voice-agent-turn-detection/python/.models/

--- a/basics/08-voice-agent-turn-detection/README.md
+++ b/basics/08-voice-agent-turn-detection/README.md
@@ -355,19 +355,26 @@ config = VoiceAgentConfigPreset._merge_configs(base_config, custom_config)
 
 ### Using EXTERNAL Mode (Manual Turn Control)
 
-The EXTERNAL preset allows manual control over turn endings. This example uses FIXED mode with the maximum silence trigger (2s) to minimize auto-triggering, then uses `force_end_of_utterance()` when Enter is pressed:
+The EXTERNAL preset allows manual control over turn endings. This example overlays FIXED mode (with the maximum 2s silence trigger to minimize auto-triggering) **and** disables `use_forced_eou` so the SDK's built-in `END_OF_UTTERANCE → finalize()` handler is registered. It then calls `force_end_of_utterance()` when Enter is pressed:
 
 ```python
 import keyboard  # Cross-platform keyboard input
-from speechmatics.voice import VoiceAgentConfig, EndOfUtteranceMode
+from speechmatics.voice import (
+    EndOfTurnConfig,
+    EndOfUtteranceMode,
+    VoiceAgentConfig,
+    VoiceAgentConfigPreset,
+)
 
-# Configure for manual control: FIXED mode with max silence trigger
-# Server allows 0-2 seconds for silence trigger
+# Configure for manual control: FIXED mode with max silence trigger.
+# use_forced_eou must be False so the SDK wires up the END_OF_UTTERANCE -> finalize()
+# handler that produces ADD_SEGMENT + END_OF_TURN events.
 config = VoiceAgentConfigPreset.load(
     "external",
     overlay_json=VoiceAgentConfig(
         end_of_utterance_mode=EndOfUtteranceMode.FIXED,
         end_of_utterance_silence_trigger=2.0,  # Max allowed by server
+        end_of_turn_config=EndOfTurnConfig(use_forced_eou=False),
     ).model_dump_json(exclude_unset=True)
 )
 
@@ -384,7 +391,9 @@ enter_task = asyncio.create_task(check_for_enter_key(client))
 ```
 
 > [!IMPORTANT]
-> The `end_of_utterance_silence_trigger` setting only applies to FIXED mode. Using FIXED mode ensures the SDK properly handles the server's END_OF_UTTERANCE response. The server allows values between 0 and 2 seconds. Setting to 0 disables automatic detection entirely.
+> Two settings must line up for manual control to produce final segments:
+> 1. `end_of_utterance_mode = FIXED` — `end_of_utterance_silence_trigger` only applies in FIXED mode (server allows 0–2s; setting 0 disables automatic detection).
+> 2. `end_of_turn_config.use_forced_eou = False` — the SDK only registers its `END_OF_UTTERANCE → finalize()` handler when this is False (it ships as `True` in the EXTERNAL preset). Without overriding it, ENTER triggers fire but no `ADD_SEGMENT` / `END_OF_TURN` events are emitted.
 
 ### Enable Smart Turn Detection
 

--- a/basics/08-voice-agent-turn-detection/python/main.py
+++ b/basics/08-voice-agent-turn-detection/python/main.py
@@ -14,6 +14,7 @@ from dotenv import load_dotenv
 from speechmatics.rt import AuthenticationError, Microphone
 from speechmatics.voice import (
     AgentServerMessageType,
+    EndOfTurnConfig,
     EndOfUtteranceMode,
     VoiceAgentClient,
     VoiceAgentConfig,
@@ -51,17 +52,20 @@ async def check_for_enter_key(client: VoiceAgentClient, preset_name: str):
 async def run_preset(preset_name: str):
     """Run a voice agent with the specified preset."""
 
-    # Load preset configuration from SDK
+    # Load preset configuration from SDK.
     if preset_name == "external":
-        # For external/manual control, use FIXED mode with max silence trigger (2s)
-        # This minimizes auto-triggering while allowing force_end_of_utterance()
-        # to work correctly (SDK only handles END_OF_UTTERANCE events in FIXED mode)
-        # Note: Server allows 0-2 seconds for silence trigger
+        # The SDK only registers its END_OF_UTTERANCE -> finalize() handler when
+        # _uses_fixed_eou is true, which requires FIXED mode AND use_forced_eou=False
+        # (see speechmatics.voice._client). The "external" preset ships with
+        # use_forced_eou=True, so we must override BOTH fields in the overlay or
+        # ENTER triggers will never produce final segments. Silence trigger is set
+        # to the server max (2.0s) to minimize accidental auto-fires.
         config = VoiceAgentConfigPreset.load(
             "external",
             overlay_json=VoiceAgentConfig(
                 end_of_utterance_mode=EndOfUtteranceMode.FIXED,
                 end_of_utterance_silence_trigger=2.0,
+                end_of_turn_config=EndOfTurnConfig(use_forced_eou=False),
             ).model_dump_json(exclude_unset=True),
         )
     else:


### PR DESCRIPTION
The FIXED-mode overlay inherited use_forced_eou=True from the preset, which both fails the SDK validator and suppresses the END_OF_UTTERANCE -> finalize() handler. Override use_forced_eou=False so ENTER triggers emit final segments, and update the README to match.