### PR TITLE
Fix: pipecat simple-voice-bot example for pipecat 1.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ basics/11-voice-api-explorer/python/sample.wav
 basics/11-voice-api-explorer/python/test_mulaw.py
 
 basics/08-voice-agent-turn-detection/python/.models/
+
+integrations/livekit/02-telephony-twilio/python/.models/

--- a/integrations/pipecat/01-simple-voice-bot/python/main.py
+++ b/integrations/pipecat/01-simple-voice-bot/python/main.py
@@ -19,15 +19,15 @@ import aiohttp
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.audio.vad.vad_analyzer import VADParams
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
-from pipecat.processors.aggregators.llm_response import (
-    LLMAssistantContextAggregator,
-    LLMUserContextAggregator,
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import (
+    LLMAssistantAggregator,
+    LLMUserAggregator,
 )
-from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
+from pipecat.processors.audio.vad_processor import VADProcessor
 from pipecat.services.elevenlabs.tts import ElevenLabsTTSService
 from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.services.speechmatics.stt import SpeechmaticsSTTService
@@ -50,12 +50,13 @@ async def main():
 
     Pipeline flow:
     1. Local Microphone -> Audio input from user
-    2. Speechmatics STT -> Transcribes speech to text
-    3. User Aggregator -> Builds user message for LLM
-    4. OpenAI LLM -> Generates response
-    5. ElevenLabs TTS -> Converts response to speech
-    6. Local Speakers -> Audio output to user
-    7. Assistant Aggregator -> Tracks assistant responses
+    2. Silero VAD -> Detects speech start/stop; signals end-of-turn to STT
+    3. Speechmatics STT -> Transcribes speech to text
+    4. User Aggregator -> Builds user message for LLM
+    5. OpenAI LLM -> Generates response
+    6. ElevenLabs TTS -> Converts response to speech
+    7. Local Speakers -> Audio output to user
+    8. Assistant Aggregator -> Tracks assistant responses
     """
     # Check required API keys first for immediate feedback
     missing_keys = []
@@ -78,22 +79,30 @@ async def main():
     agent_prompt = load_agent_prompt()
 
     async with aiohttp.ClientSession() as session:
-        # Local Audio Transport (Microphone + Speakers)
+        # Local Audio Transport (Microphone + Speakers).
+        # NOTE: in pipecat 1.x, transport params no longer accept vad_analyzer;
+        # VAD is now a separate FrameProcessor inserted into the pipeline below.
         transport = LocalAudioTransport(
             LocalAudioTransportParams(
                 audio_in_enabled=True,
                 audio_out_enabled=True,
-                vad_analyzer=SileroVADAnalyzer(params=VADParams(min_volume=0.6)),
             )
         )
 
-        # Speech-to-Text: Speechmatics
+        # Voice Activity Detection: Silero VAD as a pipeline processor. When
+        # speech stops, this broadcasts VADUserStoppedSpeakingFrame, which the
+        # Speechmatics STT service uses to drive end-of-utterance in EXTERNAL
+        # turn-detection mode (the service's default).
+        vad_processor = VADProcessor(vad_analyzer=SileroVADAnalyzer())
+
+        # Speech-to-Text: Speechmatics. Defaults turn_detection_mode to EXTERNAL,
+        # so user turns close when the pipeline emits VADUserStoppedSpeakingFrame
+        # from the VAD processor above (rather than a server-side silence timer).
         stt = SpeechmaticsSTTService(
             api_key=os.getenv("SPEECHMATICS_API_KEY"),
-            params=SpeechmaticsSTTService.InputParams(
+            settings=SpeechmaticsSTTService.Settings(
                 enable_diarization=True,
                 focus_speakers=["S1"],
-                end_of_utterance_silence_trigger=0.5,
                 speaker_active_format="<{speaker_id}>{text}</{speaker_id}>",
                 speaker_passive_format="<PASSIVE><{speaker_id}>{text}</{speaker_id}></PASSIVE>",
             ),
@@ -103,13 +112,13 @@ async def main():
         tts = ElevenLabsTTSService(
             aiohttp_session=session,
             api_key=os.getenv("ELEVENLABS_API_KEY"),
-            voice_id="21m00Tcm4TlvDq8ikWAM",  # Rachel
+            settings=ElevenLabsTTSService.Settings(voice="21m00Tcm4TlvDq8ikWAM"),  # Rachel
         )
 
         # Language Model: OpenAI
         llm = OpenAILLMService(
             api_key=os.getenv("OPENAI_API_KEY"),
-            model="gpt-4o-mini",
+            settings=OpenAILLMService.Settings(model="gpt-4o-mini"),
         )
 
         # Conversation Context
@@ -122,14 +131,17 @@ async def main():
             },
         ]
 
-        context = OpenAILLMContext(messages)
-        user_aggregator = LLMUserContextAggregator(context)
-        assistant_aggregator = LLMAssistantContextAggregator(context)
+        context = LLMContext(messages)
+        user_aggregator = LLMUserAggregator(context)
+        assistant_aggregator = LLMAssistantAggregator(context)
 
-        # Build Pipeline
+        # Build Pipeline. The VAD processor sits between mic input and STT so
+        # it can detect speech stop and emit VADUserStoppedSpeakingFrame, which
+        # drives end-of-utterance for the Speechmatics STT service.
         pipeline = Pipeline(
             [
                 transport.input(),
+                vad_processor,
                 stt,
                 user_aggregator,
                 llm,


### PR DESCRIPTION
Three issues prevented the example from running on pipecat 1.1.0:

1. Aggregator imports moved/renamed: LLMUserContextAggregator and LLMAssistantContextAggregator are now LLMUserAggregator and LLMAssistantAggregator under llm_response_universal, and OpenAILLMContext is replaced by LLMContext under llm_context.

2. Service constructors emit DeprecationWarning for params=, voice_id=, and model= kwargs. Use settings=<Service>.Settings(...) for SpeechmaticsSTTService, ElevenLabsTTSService, and OpenAILLMService.

3. The example passed vad_analyzer= to LocalAudioTransportParams, but in pipecat 1.x that param has been removed — the kwarg was silently swallowed by pydantic, so no VAD ever ran. Without a VAD-stop signal, Speechmatics' default EXTERNAL turn detection mode never finalized the user's turn, the LLM was never invoked, and the agent stayed silent. Insert a dedicated VADProcessor (Silero) into the pipeline so VADUserStoppedSpeakingFrame propagates to the STT service and triggers client.finalize().