### PR TITLE
Fix: stop .gitignore dropping JS/TS tsconfig and src/lib files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,10 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+# Anchored to repo root so these Python build-artifact rules don't match
+# nested JS/TS source dirs (e.g. client/src/lib/) in multi-language examples.
+/lib/
+/lib64/
 parts/
 sdist/
 var/
@@ -69,10 +71,17 @@ output/
 *.srt
 *.vtt
 
-# JSON output from transcription examples (but NOT package.json files)
+# JSON output from transcription examples (but NOT package.json or tooling config)
 *.json
 !package.json
 !package-lock.json
+# JS/TS tooling config that must stay tracked (multi-language examples)
+!tsconfig.json
+!tsconfig.*.json
+!jsconfig.json
+!biome.json
+!components.json
+!vercel.json
 
 
 # Logs


### PR DESCRIPTION
The root .gitignore was Python-oriented and silently excluded files needed by multi-language (JS/TS) examples:

- `lib/` matched nested `client/src/lib/` (Next.js source), dropping whole source dirs. Anchored to `/lib/` + `/lib64/` so it only targets repo-root Python build artifacts; nested build/venv libs stay covered by the existing `build/` and `venv/` rules.
- `*.json` matched `tsconfig.json` and other tooling config. Added negations for tsconfig/jsconfig/biome/components/vercel so JS/TS config stays tracked while transcription output JSON remains ignored.

Surfaced by the Agora conversational-AI integration PR, which failed to build because client/tsconfig.json and client/src/lib/* were never committed (silently ignored).