### PR TITLE
Fix: skip welcome message for maintainers' own PRs/issues

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -15,8 +15,18 @@ permissions:
 jobs:
   thank_first_time_contributors:
     runs-on: ubuntu-latest
+    # Only welcome genuine external contributors:
+    # - skip bots
+    # - skip maintainers (owner/member/collaborator) so self-merged maintainer
+    #   PRs don't get falsely flagged as a "first contribution"
     if: >-
       (github.event.pull_request.user.type || github.event.issue.user.type) != 'Bot'
+      && github.event.pull_request.author_association != 'OWNER'
+      && github.event.pull_request.author_association != 'MEMBER'
+      && github.event.pull_request.author_association != 'COLLABORATOR'
+      && github.event.issue.author_association != 'OWNER'
+      && github.event.issue.author_association != 'MEMBER'
+      && github.event.issue.author_association != 'COLLABORATOR'
     steps:
       - name: Welcome first-time contributors
         uses: actions/first-interaction@v3


### PR DESCRIPTION
The welcome workflow fired "Thanks for your first contribution" on every maintainer PR, even after many merged PRs.

The welcome message is intended for external first-time contributors, so guard the job to skip OWNER/MEMBER/COLLABORATOR authors (for both pull_request and issue events). Genuine external contributors are unaffected.